### PR TITLE
Support boolean and number arrays

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,7 +1,6 @@
 import {Opts as MinimistOptions} from 'minimist';
 
-type PrimitiveOptionType = 'string' | 'boolean' | 'number';
-export type OptionType = PrimitiveOptionType | 'array' | ReadonlyArray<PrimitiveOptionType>;
+export type OptionType = 'string' | 'boolean' | 'number' | 'array' | 'string-array' | 'boolean-array' | 'number-array';
 
 export interface BaseOption<
 	TypeOptionType extends OptionType,
@@ -27,9 +26,9 @@ export type StringOption = BaseOption<'string', string>;
 export type BooleanOption = BaseOption<'boolean', boolean>;
 export type NumberOption = BaseOption<'number', number>;
 export type DefaultArrayOption = BaseOption<'array', ReadonlyArray<string>>;
-export type StringArrayOption = BaseOption<ReadonlyArray<'string'>, ReadonlyArray<string>>;
-export type NumberArrayOption = BaseOption<ReadonlyArray<'number'>, ReadonlyArray<number>>;
-export type BooleanArrayOption = BaseOption<ReadonlyArray<'boolean'>, ReadonlyArray<boolean>>;
+export type StringArrayOption = BaseOption<'string-array', ReadonlyArray<string>>;
+export type BooleanArrayOption = BaseOption<'boolean-array', ReadonlyArray<boolean>>;
+export type NumberArrayOption = BaseOption<'number-array', ReadonlyArray<number>>;
 
 type MinimistOption = NonNullable<
 	| MinimistOptions['stopEarly']
@@ -45,8 +44,8 @@ export type Options = {
 		| NumberOption
 		| DefaultArrayOption
 		| StringArrayOption
-		| NumberArrayOption
 		| BooleanArrayOption
+		| NumberArrayOption
 		| MinimistOption;  // Workaround for https://github.com/microsoft/TypeScript/issues/17867
 };
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,6 +1,7 @@
 import {Opts as MinimistOptions} from 'minimist';
 
-export type OptionType = 'string' | 'boolean' | 'number' | 'array';
+type PrimitiveOptionType = 'string' | 'boolean' | 'number';
+export type OptionType = PrimitiveOptionType | 'array' | ReadonlyArray<PrimitiveOptionType>;
 
 export interface BaseOption<
 	TypeOptionType extends OptionType,
@@ -25,23 +26,27 @@ export interface BaseOption<
 export type StringOption = BaseOption<'string', string>;
 export type BooleanOption = BaseOption<'boolean', boolean>;
 export type NumberOption = BaseOption<'number', number>;
-export type ArrayOption<ArrayContentType = unknown> = BaseOption<
-	'array',
-	ReadonlyArray<ArrayContentType>
->;
+export type DefaultArrayOption = BaseOption<'array', ReadonlyArray<string>>;
+export type StringArrayOption = BaseOption<ReadonlyArray<'string'>, ReadonlyArray<string>>;
+export type NumberArrayOption = BaseOption<ReadonlyArray<'number'>, ReadonlyArray<number>>;
+export type BooleanArrayOption = BaseOption<ReadonlyArray<'boolean'>, ReadonlyArray<boolean>>;
+
 type MinimistOption = NonNullable<
 	| MinimistOptions['stopEarly']
 	| MinimistOptions['unknown']
 	| MinimistOptions['--']
 >;
 
-export type Options<ArrayOptionContentType = unknown> = {
+export type Options = {
 	[key: string]:
 		| OptionType
 		| StringOption
 		| BooleanOption
 		| NumberOption
-		| ArrayOption<ArrayOptionContentType>
+		| DefaultArrayOption
+		| StringArrayOption
+		| NumberArrayOption
+		| BooleanArrayOption
 		| MinimistOption;  // Workaround for https://github.com/microsoft/TypeScript/issues/17867
 };
 

--- a/index.js
+++ b/index.js
@@ -26,7 +26,9 @@ const prettyPrint = output =>
 		kindOf(output) === 'string' ? JSON.stringify(output) : output;
 
 const passthroughOptions = ['stopEarly', 'unknown', '--'];
-const availableTypes = ['string', 'boolean', 'number', 'array', 'string-array', 'boolean-array', 'number-array'];
+const primitiveTypes = ['string', 'boolean', 'number'];
+const arrayTypes = primitiveTypes.map(t => `${t}-array`);
+const availableTypes = [...primitiveTypes, 'array', ...arrayTypes];
 
 const buildOptions = options => {
 	options = options || {};
@@ -56,14 +58,13 @@ const buildOptions = options => {
 		if (isPlainObject(value)) {
 			const props = value;
 			const {type} = props;
-			const isTypedArrayType = type && type.endsWith('-array');
 
 			if (type) {
 				if (!availableTypes.includes(type)) {
 					throw new TypeError(`Expected type of "${key}" to be one of ${prettyPrint(availableTypes)}, got ${prettyPrint(type)}`);
 				}
 
-				if (isTypedArrayType) {
+				if (arrayTypes.includes(type)) {
 					const [elementType] = type.split('-');
 					push(result, 'array', {key, [elementType]: true});
 				} else {
@@ -73,7 +74,7 @@ const buildOptions = options => {
 
 			if ({}.hasOwnProperty.call(props, 'default')) {
 				const {default: defaultValue} = props;
-				const defaultType = isTypedArrayType && Array.isArray(defaultValue) && defaultValue.length > 0 ?
+				const defaultType = arrayTypes.includes(type) && Array.isArray(defaultValue) && defaultValue.length > 0 ?
 					`${kindOf(defaultValue[0])}-array` :
 					kindOf(defaultValue);
 

--- a/index.js
+++ b/index.js
@@ -20,10 +20,11 @@ const insert = (obj, prop, key, value) => {
 	obj[prop][key] = value;
 };
 
-const prettyPrint = output =>
-	Array.isArray(output) ?
+const prettyPrint = output => {
+	return Array.isArray(output) ?
 		`[${output.map(prettyPrint).join(', ')}]` :
 		kindOf(output) === 'string' ? JSON.stringify(output) : output;
+};
 
 const resolveType = value => {
 	if (Array.isArray(value) && value.length > 0) {

--- a/index.js
+++ b/index.js
@@ -21,9 +21,9 @@ const insert = (obj, prop, key, value) => {
 };
 
 const prettyPrint = output =>
-	Array.isArray(output)
-		? `[${output.map(prettyPrint).join(', ')}]`
-		: kindOf(output) === 'string' ? JSON.stringify(output) : output;
+	Array.isArray(output) ?
+		`[${output.map(prettyPrint).join(', ')}]` :
+		kindOf(output) === 'string' ? JSON.stringify(output) : output;
 
 const passthroughOptions = ['stopEarly', 'unknown', '--'];
 const availableTypes = ['string', 'boolean', 'number', 'array', 'string-array', 'boolean-array', 'number-array'];
@@ -64,9 +64,8 @@ const buildOptions = options => {
 
 				if (type.endsWith('-array')) {
 					const [elementType] = type.split('-');
-					push(result, "array", {key, [elementType]: true});
-				}
-				else {
+					push(result, 'array', {key, [elementType]: true});
+				} else {
 					push(result, type, key);
 				}
 			}

--- a/index.js
+++ b/index.js
@@ -69,14 +69,14 @@ const buildOptions = options => {
 				const [elementType] = type;
 
 				if (!primitiveTypes.includes(elementType)) {
-					throw new TypeError(`Expected "${key}" to be one of ${prettyPrint(arrayTypes)}, got [${(prettyPrint(elementType))}]`);
+					throw new TypeError(`Expected type of "${key}" to be one of ${prettyPrint(arrayTypes)}, got [${(prettyPrint(elementType))}]`);
 				}
 
 				push(result, "array", {key, [elementType]: true});
 			}
 			else if (type) {
 				if (!availableTypes.includes(type)) {
-					throw new TypeError(`Expected "${key}" to be one of ${prettyPrint(availableTypes)}, got ${prettyPrint(type)}`);
+					throw new TypeError(`Expected type of "${key}" to be one of ${prettyPrint(availableTypes)}, got ${prettyPrint(type)}`);
 				}
 
 				push(result, type, key);

--- a/index.js
+++ b/index.js
@@ -36,12 +36,13 @@ const resolveType = value => {
 };
 
 const normalizeExpectedType = (type, defaultValue) => {
-	const inferedType = type === 'array' ? 'string-array' : type;
-	if (arrayTypes.includes(inferedType) && Array.isArray(defaultValue) && defaultValue.length === 0) {
+	const inferredType = type === 'array' ? 'string-array' : type;
+	
+	if (arrayTypes.includes(inferredType) && Array.isArray(defaultValue) && defaultValue.length === 0) {
 		return 'array';
 	}
 
-	return inferedType;
+	return inferredType;
 };
 
 const passthroughOptions = ['stopEarly', 'unknown', '--'];

--- a/index.js
+++ b/index.js
@@ -74,12 +74,16 @@ const buildOptions = options => {
 
 			if ({}.hasOwnProperty.call(props, 'default')) {
 				const {default: defaultValue} = props;
-				const defaultType = arrayTypes.includes(type) && Array.isArray(defaultValue) && defaultValue.length > 0 ?
+				const defaultType = Array.isArray(defaultValue) && defaultValue.length > 0 ?
 					`${kindOf(defaultValue[0])}-array` :
 					kindOf(defaultValue);
+				const inferencedType = type === 'array' ? 'string-array' : type;
+				const expectedType = arrayTypes.includes(inferencedType) && Array.isArray(defaultValue) && defaultValue.length === 0 ?
+					'array' :
+					inferencedType;
 
-				if (type && type !== defaultType) {
-					throw new TypeError(`Expected "${key}" default value to be of type "${type}", got ${prettyPrint(defaultType)}`);
+				if (expectedType && expectedType !== defaultType) {
+					throw new TypeError(`Expected "${key}" default value to be of type "${expectedType}", got ${prettyPrint(defaultType)}`);
 				}
 
 				insert(result, 'default', key, defaultValue);

--- a/index.js
+++ b/index.js
@@ -56,13 +56,14 @@ const buildOptions = options => {
 		if (isPlainObject(value)) {
 			const props = value;
 			const {type} = props;
+			const isTypedArrayType = type && type.endsWith('-array');
 
 			if (type) {
 				if (!availableTypes.includes(type)) {
 					throw new TypeError(`Expected type of "${key}" to be one of ${prettyPrint(availableTypes)}, got ${prettyPrint(type)}`);
 				}
 
-				if (type.endsWith('-array')) {
+				if (isTypedArrayType) {
 					const [elementType] = type.split('-');
 					push(result, 'array', {key, [elementType]: true});
 				} else {
@@ -72,7 +73,9 @@ const buildOptions = options => {
 
 			if ({}.hasOwnProperty.call(props, 'default')) {
 				const {default: defaultValue} = props;
-				const defaultType = Array.isArray(defaultValue) ? `${kindOf(defaultValue[0])}-array` : kindOf(defaultValue);
+				const defaultType = isTypedArrayType && Array.isArray(defaultValue) && defaultValue.length > 0 ?
+					`${kindOf(defaultValue[0])}-array` :
+					kindOf(defaultValue);
 
 				if (type && type !== defaultType) {
 					throw new TypeError(`Expected "${key}" default value to be of type "${type}", got ${prettyPrint(defaultType)}`);

--- a/index.test-d.ts
+++ b/index.test-d.ts
@@ -33,6 +33,27 @@ buildOptions({
 		default: []
 	}
 });
+buildOptions({
+	strings: {
+		type: ['string'],
+		alias: 's',
+		default: ['a']
+	}
+});
+buildOptions({
+	numbers: {
+		type: ['number'],
+		alias: 'n',
+		default: [0]
+	}
+});
+buildOptions({
+	booleans: {
+		type: ['boolean'],
+		alias: 'b',
+		default: [false]
+	}
+});
 
 const options = buildOptions({
 	name: {
@@ -57,6 +78,24 @@ const options = buildOptions({
 		type: 'array',
 		alias: 'a',
 		default: []
+	},
+
+	strings: {
+		type: ['string'],
+		alias: 's',
+		default: ['a']
+	},
+
+	numbers: {
+		type: ['number'],
+		alias: 'n',
+		default: [0]
+	},
+
+	booleans: {
+		type: ['boolean'],
+		alias: 'b',
+		default: [false]
 	},
 
 	published: 'boolean',

--- a/index.test-d.ts
+++ b/index.test-d.ts
@@ -5,6 +5,9 @@ buildOptions({name: 'string'});
 buildOptions({force: 'boolean'});
 buildOptions({score: 'number'});
 buildOptions({array: 'array'});
+buildOptions({array: 'string-array'});
+buildOptions({array: 'boolean-array'});
+buildOptions({array: 'number-array'});
 buildOptions({
 	name: {
 		type: 'string',
@@ -35,23 +38,23 @@ buildOptions({
 });
 buildOptions({
 	strings: {
-		type: ['string'],
+		type: 'string-array',
 		alias: 's',
-		default: ['a']
-	}
-});
-buildOptions({
-	numbers: {
-		type: ['number'],
-		alias: 'n',
-		default: [0]
+		default: ['a', 'b']
 	}
 });
 buildOptions({
 	booleans: {
-		type: ['boolean'],
+		type: 'boolean-array',
 		alias: 'b',
-		default: [false]
+		default: [true, false]
+	}
+});
+buildOptions({
+	numbers: {
+		type: 'number-array',
+		alias: 'n',
+		default: [0, 1]
 	}
 });
 
@@ -81,21 +84,21 @@ const options = buildOptions({
 	},
 
 	strings: {
-		type: ['string'],
+		type: 'string-array',
 		alias: 's',
-		default: ['a']
-	},
-
-	numbers: {
-		type: ['number'],
-		alias: 'n',
-		default: [0]
+		default: ['a', 'b']
 	},
 
 	booleans: {
-		type: ['boolean'],
+		type: 'boolean-array',
 		alias: 'b',
-		default: [false]
+		default: [true, false]
+	},
+
+	numbers: {
+		type: 'number-array',
+		alias: 'n',
+		default: [0, 1]
 	},
 
 	published: 'boolean',

--- a/package.json
+++ b/package.json
@@ -22,7 +22,8 @@
   ],
   "dependencies": {
     "arrify": "^1.0.1",
-    "is-plain-obj": "^1.1.0"
+    "is-plain-obj": "^1.1.0",
+    "kind-of": "^6.0.3"
   },
   "devDependencies": {
     "@types/minimist": "^1.2.0",

--- a/readme.md
+++ b/readme.md
@@ -101,7 +101,7 @@ const options = {
 const args = minimist(process.argv.slice(2), options);
 ```
 
-## Note about array options
+## Array options
 
 The `array` types are only supported by [yargs](https://npmjs.org/package/yargs).
 

--- a/readme.md
+++ b/readme.md
@@ -1,7 +1,9 @@
 # minimist-options [![Build Status](https://travis-ci.org/vadimdemedes/minimist-options.svg?branch=master)](https://travis-ci.org/vadimdemedes/minimist-options)
 
-> Write options for [minimist](https://npmjs.org/package/minimist) in a comfortable way.
+> Write options for [minimist](https://npmjs.org/package/minimist)* in a comfortable way.
 > Support string, boolean, number and array options.
+
+\* and compatible successors such as [yargs](https://npmjs.org/package/yargs).
 
 ## Installation
 
@@ -40,6 +42,24 @@ const options = buildOptions({
 		default: []
 	},
 
+	strings: {
+		type: 'string-array',
+		alias: 's',
+		default: ['a', 'b']
+	},
+
+	booleans: {
+		type: 'boolean-array',
+		alias: 'b',
+		default: [true, false]
+	},
+
+	numbers: {
+		type: 'number-array',
+		alias: 'n',
+		default: [0, 1]
+	},
+
 	published: 'boolean',
 
 	// Special option for positional arguments (`_` in minimist)
@@ -57,7 +77,12 @@ const minimist = require('minimist');
 const options = {
 	string: ['name', '_'],
 	number: ['score'],
-	array: ['arr'],
+	array: [
+		'arr',
+		{key: 'strings', string: true},
+		{key: 'booleans', boolean: true},
+		{key: 'numbers', number: true}
+	],
 	boolean: ['force', 'published'],
 	alias: {
 		n: 'name',
@@ -75,6 +100,12 @@ const options = {
 
 const args = minimist(process.argv.slice(2), options);
 ```
+
+## Note about array options
+
+The `array` types are only supported by [yargs](https://npmjs.org/package/yargs).
+
+[minimist](https://npmjs.org/package/minimist) does _not_ explicitly support array type options. If you set an option multiple times, it will indeed yield an array of values. However, if you only set it once, it will simply give the value as is, without wrapping it in an array. Thus, effectively ignoring `type: 'array'`.
 
 ## License
 

--- a/readme.md
+++ b/readme.md
@@ -107,7 +107,7 @@ The `array` types are only supported by [yargs](https://npmjs.org/package/yargs)
 
 [minimist](https://npmjs.org/package/minimist) does _not_ explicitly support array type options. If you set an option multiple times, it will indeed yield an array of values. However, if you only set it once, it will simply give the value as is, without wrapping it in an array. Thus, effectively ignoring `{type: 'array'}`.
 
-`{type: 'array'}` is shorthand for `{type: 'string-array'}`. To have values coerced to `boolean` or `number`, use `boolean-array` or `number-array`, resepectively.
+`{type: 'array'}` is shorthand for `{type: 'string-array'}`. To have values coerced to `boolean` or `number`, use `boolean-array` or `number-array`, respectively.
 
 ## License
 

--- a/readme.md
+++ b/readme.md
@@ -1,9 +1,7 @@
 # minimist-options [![Build Status](https://travis-ci.org/vadimdemedes/minimist-options.svg?branch=master)](https://travis-ci.org/vadimdemedes/minimist-options)
 
-> Write options for [minimist](https://npmjs.org/package/minimist)* in a comfortable way.
-> Support string, boolean, number and array options.
-
-\* and compatible successors such as [yargs](https://npmjs.org/package/yargs).
+> Write options for [minimist](https://npmjs.org/package/minimist) and [yargs](https://npmjs.org/package/yargs) in a comfortable way.
+> Supports string, boolean, number and array options.
 
 ## Installation
 

--- a/readme.md
+++ b/readme.md
@@ -105,7 +105,9 @@ const args = minimist(process.argv.slice(2), options);
 
 The `array` types are only supported by [yargs](https://npmjs.org/package/yargs).
 
-[minimist](https://npmjs.org/package/minimist) does _not_ explicitly support array type options. If you set an option multiple times, it will indeed yield an array of values. However, if you only set it once, it will simply give the value as is, without wrapping it in an array. Thus, effectively ignoring `type: 'array'`.
+[minimist](https://npmjs.org/package/minimist) does _not_ explicitly support array type options. If you set an option multiple times, it will indeed yield an array of values. However, if you only set it once, it will simply give the value as is, without wrapping it in an array. Thus, effectively ignoring `{type: 'array'}`.
+
+`{type: 'array'}` is shorthand for `{type: 'string-array'}`. To have values coerced to `boolean` or `number`, use `boolean-array` or `number-array`, resepectively.
 
 ## License
 

--- a/test.js
+++ b/test.js
@@ -28,83 +28,71 @@ test('number option', validate, {
 test('default array option', validate, {
 	arr: 'array'
 }, {
-	array: [{key: 'arr', string: true}]
+	array: ['arr']
 });
 
 test('string array option', validate, {
-	arr: ['string']
+	arr: 'string-array'
 }, {
 	array: [{key: 'arr', string: true}]
 });
 
 test('number array option', validate, {
-	arr: ['number']
+	arr: 'number-array'
 }, {
 	array: [{key: 'arr', number: true}]
 });
 
 test('boolean array option', validate, {
-	arr: ['boolean']
+	arr: 'boolean-array'
 }, {
 	array: [{key: 'arr', boolean: true}]
 });
 
 test('multiple array options', validate, {
-	xs: ['number'],
-	ys: ['boolean']
+	xs: 'number-array',
+	ys: 'boolean-array'
 }, {
 	array: [{key: 'xs', number: true}, {key: 'ys', boolean: true}]
-});
-
-test('unsupported array element type fails', t => {
-	const error = t.throws(() => {
-		minimistOptions({
-			arr: {
-				type: ['date']
-			}
-		});
-	}, TypeError);
-
-	t.is(error.message, 'Expected type of "arr" to be one of [["string"], ["boolean"], ["number"]], got ["date"]');
 });
 
 test('string array default value is not string array fails', t => {
 	const error = t.throws(() => {
 		minimistOptions({
 			arr: {
-				type: ['string'],
+				type: 'string-array',
 				default: [2]
 			}
 		});
 	}, TypeError);
 
-	t.is(error.message, 'Expected "arr" default value to be of type ["string"], got ["number"]');
+	t.is(error.message, 'Expected "arr" default value to be of type "string-array", got "number-array"');
 });
 
 test('boolean array default value is not boolean array fails', t => {
 	const error = t.throws(() => {
 		minimistOptions({
 			arr: {
-				type: ['boolean'],
+				type: 'boolean-array',
 				default: ['score']
 			}
 		});
 	}, TypeError);
 
-	t.is(error.message, 'Expected "arr" default value to be of type ["boolean"], got ["string"]');
+	t.is(error.message, 'Expected "arr" default value to be of type "boolean-array", got "string-array"');
 });
 
 test('number array default value is not number array fails', t => {
 	const error = t.throws(() => {
 		minimistOptions({
 			arr: {
-				type: ['number'],
+				type: 'number-array',
 				default: [true]
 			}
 		});
 	}, TypeError);
 
-	t.is(error.message, 'Expected "arr" default value to be of type ["number"], got ["boolean"]');
+	t.is(error.message, 'Expected "arr" default value to be of type "number-array", got "boolean-array"');
 });
 
 test('alias', validate, {
@@ -170,7 +158,7 @@ test('alias and array', validate, {
 		alias: 'a'
 	}
 }, {
-	array: [{key: 'arr', string: true}],
+	array: ['arr'],
 	alias: {
 		a: 'arr'
 	}
@@ -242,7 +230,7 @@ test('fail if type is not boolean, string, number or array', t => {
 		});
 	}, TypeError);
 
-	t.is(error.message, 'Expected type of "force" to be one of ["string", "boolean", "number", "array", ["string"], ["boolean"], ["number"]], got "bool"');
+	t.is(error.message, 'Expected type of "force" to be one of ["string", "boolean", "number", "array", "string-array", "boolean-array", "number-array"], got "bool"');
 });
 
 test('fail if boolean default value is not a boolean', t => {
@@ -298,5 +286,5 @@ test('fail if array default value is not an array', t => {
 		});
 	}, TypeError);
 
-	t.is(error.message, 'Expected "score" default value to be of type ["string"], got "string"');
+	t.is(error.message, 'Expected "score" default value to be of type "array", got "string"');
 });

--- a/test.js
+++ b/test.js
@@ -25,10 +25,86 @@ test('number option', validate, {
 	number: ['score']
 });
 
-test('array option', validate, {
+test('default array option', validate, {
 	arr: 'array'
 }, {
-	array: ['arr']
+	array: [{key: 'arr', string: true}]
+});
+
+test('string array option', validate, {
+	arr: ['string']
+}, {
+	array: [{key: 'arr', string: true}]
+});
+
+test('number array option', validate, {
+	arr: ['number']
+}, {
+	array: [{key: 'arr', number: true}]
+});
+
+test('boolean array option', validate, {
+	arr: ['boolean']
+}, {
+	array: [{key: 'arr', boolean: true}]
+});
+
+test('multiple array options', validate, {
+	xs: ['number'],
+	ys: ['boolean']
+}, {
+	array: [{key: 'xs', number: true}, {key: 'ys', boolean: true}]
+});
+
+test('unsupported array element type fails', t => {
+	const error = t.throws(() => {
+		minimistOptions({
+			arr: {
+				type: ['date']
+			}
+		});
+	}, TypeError);
+
+	t.is(error.message, 'Expected "arr" to be one of [["string"], ["boolean"], ["number"]], got ["date"]');
+});
+
+test('string array default value is not string array fails', t => {
+	const error = t.throws(() => {
+		minimistOptions({
+			arr: {
+				type: ['string'],
+				default: [2]
+			}
+		});
+	}, TypeError);
+
+	t.is(error.message, 'Expected "arr" default value to be of type ["string"], got ["number"]');
+});
+
+test('boolean array default value is not boolean array fails', t => {
+	const error = t.throws(() => {
+		minimistOptions({
+			arr: {
+				type: ['boolean'],
+				default: ['score']
+			}
+		});
+	}, TypeError);
+
+	t.is(error.message, 'Expected "arr" default value to be of type ["boolean"], got ["string"]');
+});
+
+test('number array default value is not number array fails', t => {
+	const error = t.throws(() => {
+		minimistOptions({
+			arr: {
+				type: ['number'],
+				default: [true]
+			}
+		});
+	}, TypeError);
+
+	t.is(error.message, 'Expected "arr" default value to be of type ["number"], got ["boolean"]');
 });
 
 test('alias', validate, {
@@ -94,7 +170,7 @@ test('alias and array', validate, {
 		alias: 'a'
 	}
 }, {
-	array: ['arr'],
+	array: [{key: 'arr', string: true}],
 	alias: {
 		a: 'arr'
 	}
@@ -166,7 +242,7 @@ test('fail if type is not boolean, string, number or array', t => {
 		});
 	}, TypeError);
 
-	t.is(error.message, 'Expected "force" to be one of ["string", "boolean", "number", "array"], got bool');
+	t.is(error.message, 'Expected "force" to be one of ["string", "boolean", "number", "array", ["string"], ["boolean"], ["number"]], got "bool"');
 });
 
 test('fail if boolean default value is not a boolean', t => {
@@ -180,7 +256,7 @@ test('fail if boolean default value is not a boolean', t => {
 		});
 	}, TypeError);
 
-	t.is(error.message, 'Expected "force" default value to be boolean, got string');
+	t.is(error.message, 'Expected "force" default value to be of type "boolean", got "string"');
 });
 
 test('fail if number default value is not a number', t => {
@@ -194,7 +270,7 @@ test('fail if number default value is not a number', t => {
 		});
 	}, TypeError);
 
-	t.is(error.message, 'Expected "score" default value to be number, got string');
+	t.is(error.message, 'Expected "score" default value to be of type "number", got "string"');
 });
 
 test('fail if string default value is not a string', t => {
@@ -208,7 +284,7 @@ test('fail if string default value is not a string', t => {
 		});
 	}, TypeError);
 
-	t.is(error.message, 'Expected "score" default value to be string, got number');
+	t.is(error.message, 'Expected "score" default value to be of type "string", got "number"');
 });
 
 test('fail if array default value is not an array', t => {
@@ -222,5 +298,5 @@ test('fail if array default value is not an array', t => {
 		});
 	}, TypeError);
 
-	t.is(error.message, 'Expected "score" default value to be array, got string');
+	t.is(error.message, 'Expected "score" default value to be of type ["string"], got "string"');
 });

--- a/test.js
+++ b/test.js
@@ -65,7 +65,7 @@ test('unsupported array element type fails', t => {
 		});
 	}, TypeError);
 
-	t.is(error.message, 'Expected "arr" to be one of [["string"], ["boolean"], ["number"]], got ["date"]');
+	t.is(error.message, 'Expected type of "arr" to be one of [["string"], ["boolean"], ["number"]], got ["date"]');
 });
 
 test('string array default value is not string array fails', t => {
@@ -242,7 +242,7 @@ test('fail if type is not boolean, string, number or array', t => {
 		});
 	}, TypeError);
 
-	t.is(error.message, 'Expected "force" to be one of ["string", "boolean", "number", "array", ["string"], ["boolean"], ["number"]], got "bool"');
+	t.is(error.message, 'Expected type of "force" to be one of ["string", "boolean", "number", "array", ["string"], ["boolean"], ["number"]], got "bool"');
 });
 
 test('fail if boolean default value is not a boolean', t => {

--- a/test.js
+++ b/test.js
@@ -204,6 +204,30 @@ test('default falsy value', validate, {
 	}
 });
 
+test('default array value', validate, {
+	arr: {
+		type: 'array',
+		default: ['a']
+	}
+}, {
+	array: ['arr'],
+	default: {
+		arr: ['a']
+	}
+});
+
+test('default empty array value', validate, {
+	arr: {
+		type: 'array',
+		default: []
+	}
+}, {
+	array: ['arr'],
+	default: {
+		arr: []
+	}
+});
+
 test('arguments type', validate, {
 	arguments: 'string'
 }, {

--- a/test.js
+++ b/test.js
@@ -220,11 +220,31 @@ test('default empty array value', validate, {
 	arr: {
 		type: 'array',
 		default: []
+	},
+	strings: {
+		type: 'string-array',
+		default: []
+	},
+	booleans: {
+		type: 'boolean-array',
+		default: []
+	},
+	numbers: {
+		type: 'number-array',
+		default: []
 	}
 }, {
-	array: ['arr'],
+	array: [
+		'arr',
+		{key: 'strings', string: true},
+		{key: 'booleans', boolean: true},
+		{key: 'numbers', number: true}
+	],
 	default: {
-		arr: []
+		arr: [],
+		strings: [],
+		booleans: [],
+		numbers: []
 	}
 });
 
@@ -248,8 +268,7 @@ test('fail if type is not boolean, string, number or array', t => {
 	const error = t.throws(() => {
 		minimistOptions({
 			force: {
-				type: 'bool',
-				alias: 'f'
+				type: 'bool'
 			}
 		});
 	}, TypeError);
@@ -262,7 +281,6 @@ test('fail if boolean default value is not a boolean', t => {
 		minimistOptions({
 			force: {
 				type: 'boolean',
-				alias: 'f',
 				default: 'true'
 			}
 		});
@@ -276,7 +294,6 @@ test('fail if number default value is not a number', t => {
 		minimistOptions({
 			score: {
 				type: 'number',
-				alias: 's',
 				default: '1'
 			}
 		});
@@ -290,7 +307,6 @@ test('fail if string default value is not a string', t => {
 		minimistOptions({
 			score: {
 				type: 'string',
-				alias: 's',
 				default: 1
 			}
 		});
@@ -304,11 +320,23 @@ test('fail if array default value is not an array', t => {
 		minimistOptions({
 			score: {
 				type: 'array',
-				alias: 's',
 				default: ''
 			}
 		});
 	}, TypeError);
 
-	t.is(error.message, 'Expected "score" default value to be of type "array", got "string"');
+	t.is(error.message, 'Expected "score" default value to be of type "string-array", got "string"');
+});
+
+test('fail if array default value element type is not string', t => {
+	const error = t.throws(() => {
+		minimistOptions({
+			score: {
+				type: 'array',
+				default: [1]
+			}
+		});
+	}, TypeError);
+
+	t.is(error.message, 'Expected "score" default value to be of type "string-array", got "number-array"');
 });


### PR DESCRIPTION
Adds support for boolean and number arrays, in addition to already supported string arrays.

`{type: 'array'}` is still supported and corresponds to string array, as before.

Closes #18